### PR TITLE
Ignore encoding errors (omits characters).

### DIFF
--- a/pylinter.py
+++ b/pylinter.py
@@ -235,7 +235,7 @@ def popup_error_list(view):
     if not PYLINTER_ERRORS.has_key(view_id):
         return
 
-    errors = [(key + 1, value) for key, value in PYLINTER_ERRORS[view_id].items() if key != 'visible']
+    errors = [(key + 1, unicode(value, errors='ignore')) for key, value in PYLINTER_ERRORS[view_id].items() if key != 'visible']
     line_nums, panel_items = zip(*sorted(errors, key=lambda error: error[1]))
 
     def on_done(selected_item):


### PR DESCRIPTION
Popup wasn't showing up on some files due to an exception at that point ('ascii' can't decode blah blah blah), it shows up with this fix, though some characters are omitted.

Tried to re-encode them to no luck :( Don't know if it's a Sublime Text limitation. They show up just fine on the console, though.
