### PR TITLE
add option to disable region outlines

### DIFF
--- a/Pylinter.sublime-settings
+++ b/Pylinter.sublime-settings
@@ -19,6 +19,8 @@
     "run_on_save": true,
     // Set to true to use graphical error icons
     "use_icons": false,
+    // Do not outline offending lines
+    "disable_outline": false,
     // Ignore Pylint error types. Possible values:
     // "R" : Refactor for a "good practice" metric violation
     // "C" : Convention for coding standard violation

--- a/pylinter.py
+++ b/pylinter.py
@@ -189,6 +189,11 @@ class PylinterCommand(sublime_plugin.TextCommand):
                      "R": "dot",
                      "W": "dot"}
 
+        if PylSet.get_or('disable_outline', False):
+            region_flag = sublime.HIDDEN
+        else:
+            region_flag = sublime.DRAW_OUTLINED
+
         outlines = {"C": [], "E": [], "F": [], "I": [], "R": [], "W": []}
 
         for line_num, error in PYLINTER_ERRORS[view.id()].items():
@@ -200,7 +205,7 @@ class PylinterCommand(sublime_plugin.TextCommand):
         for key, regions in outlines.items():
             view.add_regions('pylinter.' + key, regions,
                              'pylinter.' + key, icons[key],
-                             sublime.DRAW_OUTLINED)
+                             region_flag)
 
     def popup_error_list(self):
         view_id = self.view.id()


### PR DESCRIPTION
This keeps the editor from looking too cluttered if you want to ignore the errors for any amount of time.
