### PR TITLE
add option to disable specific pylint messages

### DIFF
--- a/Pylinter.sublime-settings
+++ b/Pylinter.sublime-settings
@@ -26,6 +26,6 @@
     // "E" : Error for important programming issues (i.e. most probably bug)
     // "F" : Fatal for errors which prevented further processing
     "ignore": [],
-    // a comma separated string of individual errors to disable
-    "disable": null
+    // a list of strings of individual errors to disable, ex: ["C0301"]
+    "disable": []
 }

--- a/Pylinter.sublime-settings
+++ b/Pylinter.sublime-settings
@@ -25,5 +25,7 @@
     // "W" : Warning for stylistic problems, or minor programming issues
     // "E" : Error for important programming issues (i.e. most probably bug)
     // "F" : Fatal for errors which prevented further processing
-    "ignore": []
+    "ignore": [],
+    // a comma separated string of individual errors to disable
+    "disable": null
 }

--- a/pylinter.py
+++ b/pylinter.py
@@ -149,6 +149,7 @@ class PylinterCommand(sublime_plugin.TextCommand):
         pylint_path = PylSet.get_or('pylint_path', None) or PYLINT_PATH
         pylint_rc = PylSet.get_or('pylint_rc', None) or ""
         ignore = [t.lower() for t in PylSet.get_or('ignore', [])]
+        disable_msgs = PylSet.get_or('disable', None) or ""
 
         if not pylint_path:
             msg = "Please define the full path to 'lint.py' in the settings."
@@ -169,7 +170,8 @@ class PylinterCommand(sublime_plugin.TextCommand):
                 working_dir,
                 pylint_path,
                 pylint_rc,
-                ignore)
+                ignore,
+                disable_msgs)
 
     @classmethod
     def show_errors(cls, view):
@@ -286,7 +288,8 @@ class PylinterCommand(sublime_plugin.TextCommand):
 
 class PylintThread(threading.Thread):
     """ This class creates a seperate thread to run Pylint in """
-    def __init__(self, view, pbin, ppath, cwd, lpath, lrc, ignore):
+    def __init__(self, view, pbin, ppath, cwd, lpath, lrc, ignore,
+                 disable_msgs):
         self.view = view
         # Grab the file name here, since view cannot be accessed
         # from anywhere but the main application thread
@@ -297,6 +300,7 @@ class PylintThread(threading.Thread):
         self.pylint_path = lpath
         self.pylint_rc = lrc
         self.ignore = ignore
+        self.disable_msgs = disable_msgs
 
         threading.Thread.__init__(self)
 
@@ -310,6 +314,9 @@ class PylintThread(threading.Thread):
 
         if self.pylint_rc:
             command.insert(-2, '--rcfile=%s' % self.pylint_rc)
+
+        if self.disable_msgs:
+            command.insert(-2, '--disable=%s' % self.disable_msgs)
 
         original = os.environ.get('PYTHONPATH', '')
 

--- a/pylinter.py
+++ b/pylinter.py
@@ -149,7 +149,7 @@ class PylinterCommand(sublime_plugin.TextCommand):
         pylint_path = PylSet.get_or('pylint_path', None) or PYLINT_PATH
         pylint_rc = PylSet.get_or('pylint_rc', None) or ""
         ignore = [t.lower() for t in PylSet.get_or('ignore', [])]
-        disable_msgs = PylSet.get_or('disable', None) or ""
+        disable_msgs = ",".join(PylSet.get_or('disable', []))
 
         if not pylint_path:
             msg = "Please define the full path to 'lint.py' in the settings."


### PR DESCRIPTION
This passes specific message ids to pylint's disable keyword. It allows ignoring errors on a per project basis. It also has the side effect of displaying a sublime.error_message if pylint raises an exception.
