### PR TITLE
add option to place status messages in a specific view

### DIFF
--- a/Pylinter.sublime-settings
+++ b/Pylinter.sublime-settings
@@ -19,6 +19,9 @@
     "run_on_save": true,
     // Set to true to use graphical error icons
     "use_icons": false,
+    "disable_outline": false,
+    // Status messages stay as long as cursor is on an error line
+    "message_stay": false,
     // Ignore Pylint error types. Possible values:
     // "R" : Refactor for a "good practice" metric violation
     // "C" : Convention for coding standard violation

--- a/pylinter.py
+++ b/pylinter.py
@@ -360,6 +360,7 @@ class BackgroundPylinter(sublime_plugin.EventListener):
     def __init__(self):
         sublime_plugin.EventListener.__init__(self)
         self.last_selected_line = -1
+        self.message_stay = PylSet.get_or("message_stay", False)
         self.status_active = False
 
     def _last_selected_lineno(self, view):
@@ -378,9 +379,12 @@ class BackgroundPylinter(sublime_plugin.EventListener):
             if last_selected_line != self.last_selected_line:
                 self.last_selected_line = last_selected_line
                 if self.last_selected_line in PYLINTER_ERRORS[view_id]:
-                    view.set_status('Pylinter', PYLINTER_ERRORS[view_id]
-                                               [self.last_selected_line])
-                    self.status_active = True
+                    err_str = PYLINTER_ERRORS[view_id][self.last_selected_line]
+                    if self.message_stay:
+                        view.set_status('Pylinter', err_str)
+                        self.status_active = True
+                    else:
+                        sublime.status_message(err_str)
                 elif self.status_active:
                     view.erase_status('Pylinter')
                     self.status_active = False

--- a/pylinter.py
+++ b/pylinter.py
@@ -360,6 +360,7 @@ class BackgroundPylinter(sublime_plugin.EventListener):
     def __init__(self):
         sublime_plugin.EventListener.__init__(self)
         self.last_selected_line = -1
+        self.status_active = False
 
     def _last_selected_lineno(self, view):
         return view.rowcol(view.sel()[0].end())[0]
@@ -377,5 +378,9 @@ class BackgroundPylinter(sublime_plugin.EventListener):
             if last_selected_line != self.last_selected_line:
                 self.last_selected_line = last_selected_line
                 if self.last_selected_line in PYLINTER_ERRORS[view_id]:
-                    sublime.status_message(PYLINTER_ERRORS[view_id]
-                                           [self.last_selected_line])
+                    view.set_status('Pylinter', PYLINTER_ERRORS[view_id]
+                                               [self.last_selected_line])
+                    self.status_active = True
+                elif self.status_active:
+                    view.erase_status('Pylinter')
+                    self.status_active = False


### PR DESCRIPTION
Placing status messages in a specific view means they don't timeout; this is useful for longer messages. Also, messages only show up under the file where the error occurred.
