### PR TITLE
Issue #34 actual workaround keeping the globals

### DIFF
--- a/pylinter.py
+++ b/pylinter.py
@@ -25,12 +25,15 @@ if ST3:
 else:
     import multiconf
 
-py_version = sys.version_info[0]
+PY_VERSION = sys.version_info[0]
 
 #pylint: disable=E1101
 
 # To override this, set the 'verbose' setting in the configuration file
 PYLINTER_VERBOSE = False
+
+# Flag to check whether settings are loaded.
+LOADED = False
 
 def speak(*msg):
     """ Log messages to the console if VERBOSE is True """
@@ -44,7 +47,10 @@ if os.name == "nt":
 else:
     STARTUPINFO = None
 
-pylint_settings = sublime.load_settings('Pylinter.sublime-settings')
+# Define placeholder globals for the globals that require the settings file
+PYLINT_SETTINGS = None
+P_PYLINT_ERROR = None
+PYLINT_VERSION = None
 
 class PylSet(object):
     """ Pylinter Settings class"""
@@ -58,7 +64,7 @@ class PylSet(object):
         except AttributeError:
             pass
 
-        return pylint_settings
+        return PYLINT_SETTINGS
 
     @classmethod
     def get(cls, setting_name):
@@ -73,7 +79,7 @@ class PylSet(object):
 
         if isinstance(settings_obj, collections.Iterable):
             if not setting_name in settings_obj:
-                settings_obj = pylint_settings
+                settings_obj = PYLINT_SETTINGS
         return multiconf.get(settings_obj, setting_name, default)
 
     @classmethod
@@ -86,7 +92,7 @@ class PylSet(object):
         python_path = cls.get_or('python_path', [])
         python_path = PATH_SEPERATOR.join([str(p) for p in python_path])
         working_dir = cls.get_or('working_dir', None)
-        pylint_path = cls.get_lint_path()
+        pylint_path = cls.get_lint_path(py_bin=python_bin)
         pylint_rc = cls.get_or('pylint_rc', None) or ""
         ignore = [t.lower() for t in cls.get_or('ignore', [])]
 
@@ -115,13 +121,13 @@ class PylSet(object):
                 pylint_extra)
 
     @classmethod
-    def get_lint_path(cls):
+    def get_lint_path(cls, py_bin = "python"):
         pylint_path = PylSet.get_or('pylint_path', None)
 
         if not pylint_path:
-            cmd = ["python",
+            cmd = [py_bin,
                    "-c"]
-            if py_version == 2:
+            if PY_VERSION == 2:
                 cmd.append("import pylint; print pylint.__path__[0]")
             else:
                 cmd.append("import pylint; print(pylint.__path__[0])")
@@ -158,25 +164,7 @@ class PylSet(object):
 class PylSetException(Exception):
     pass
 
-PYLINT_VERSION = PylSet.get_lint_version()
 
-# Regular expression to disect Pylint error messages
-if PYLINT_VERSION[0] == 0:
-    # Regular expression to disect Pylint error messages
-    P_PYLINT_ERROR = re.compile(r"""
-        ^(?P<file>.+?):(?P<line>[0-9]+):\ # file name and line number
-        \[(?P<type>[a-z])(?P<errno>\d+)   # message type and error number
-                                          # e.g. E0101
-        (,\ (?P<hint>.+))?\]\             # optional class or function name
-        (?P<msg>.*)                       # finally, the error message
-        """, re.IGNORECASE | re.VERBOSE)
-else:
-    P_PYLINT_ERROR = re.compile(r"""
-        ^(?P<file>.+?):(?P<line>[0-9]+): # file name and line number
-        (?P<type>[a-z])(?P<errno>\d+):   # message type and error number,
-                                         # e.g. E0101
-        (?P<msg>.*)                      # finally, the error message
-        """, re.IGNORECASE | re.VERBOSE)
 
 # The output format we want PyLint's error messages to be in
 PYLINT_FORMAT = '--msg-template={path}:{line}:{msg_id}:{msg}'
@@ -187,9 +175,40 @@ PYLINTER_ERRORS = {}
 PATH_SEPERATOR = ';' if os.name == "nt" else ':'
 SEPERATOR_PATTERN = ';' if os.name == "nt" else '[:;]'
 
+def setPylinterGlobals():
+    global P_PYLINT_ERROR
+    global PYLINT_VERSION
+    print("Setting Pylinter Globals")
+    if LOADED:
+        PYLINT_VERSION = PylSet.get_lint_version()
+        # Regular expression to disect Pylint error messages
+        if PYLINT_VERSION[0] == 0:
+            # Regular expression to disect Pylint error messages
+            P_PYLINT_ERROR = re.compile(r"""
+                ^(?P<file>.+?):(?P<line>[0-9]+):\ # file name and line number
+                \[(?P<type>[a-z])(?P<errno>\d+)   # message type and error number
+                                                  # e.g. E0101
+                (,\ (?P<hint>.+))?\]\             # optional class or function name
+                (?P<msg>.*)                       # finally, the error message
+                """, re.IGNORECASE | re.VERBOSE)
+        else:
+            P_PYLINT_ERROR = re.compile(r"""
+                ^(?P<file>.+?):(?P<line>[0-9]+): # file name and line number
+                (?P<type>[a-z])(?P<errno>\d+):   # message type and error number,
+                                                 # e.g. E0101
+                (?P<msg>.*)                      # finally, the error message
+                """, re.IGNORECASE | re.VERBOSE)
+    else:
+        PYLINT_VERSION = None
+
+
 class PylinterCommand(sublime_plugin.TextCommand):
 
     def run(self, edit, **kwargs):
+        global PYLINT_VERSION
+        global LOADED
+        if LOADED:
+            setPylinterGlobals()
 
         settings = PylSet.read_settings()
 
@@ -446,40 +465,46 @@ class PylintThread(threading.Thread):
 
         PylinterCommand.show_errors(self.view)
 
+if LOADED:
+    class BackgroundPylinter(sublime_plugin.EventListener):
+        def __init__(self):
+            sublime_plugin.EventListener.__init__(self)
+            self.last_selected_line = -1
+            self.message_stay = PylSet.get_or("message_stay", False)
+            self.status_active = False
 
-class BackgroundPylinter(sublime_plugin.EventListener):
-    def __init__(self):
-        sublime_plugin.EventListener.__init__(self)
-        self.last_selected_line = -1
-        self.message_stay = PylSet.get_or("message_stay", False)
-        self.status_active = False
+        def _last_selected_lineno(self, view):
+            return view.rowcol(view.sel()[0].end())[0]
 
-    def _last_selected_lineno(self, view):
-        return view.rowcol(view.sel()[0].end())[0]
+        def on_post_save(self, view):
+            if view.file_name().endswith('.py') and PylSet.get_or('run_on_save',
+                                                                  False):
+                view.run_command('pylinter')
 
-    def on_post_save(self, view):
-        if view.file_name().endswith('.py') and PylSet.get_or('run_on_save',
-                                                              False):
-            view.run_command('pylinter')
+        def on_selection_modified(self, view):
+            view_id = view.id()
+            if view_id in PYLINTER_ERRORS:
+                last_selected_line = self._last_selected_lineno(view)
 
-    def on_selection_modified(self, view):
-        view_id = view.id()
-        if view_id in PYLINTER_ERRORS:
-            last_selected_line = self._last_selected_lineno(view)
-
-            if last_selected_line != self.last_selected_line:
-                self.last_selected_line = last_selected_line
-                if self.last_selected_line in PYLINTER_ERRORS[view_id]:
-                    err_str = PYLINTER_ERRORS[view_id][self.last_selected_line]
-                    if self.message_stay:
-                        view.set_status('Pylinter', err_str)
-                        self.status_active = True
-                    else:
-                        sublime.status_message(err_str)
-                elif self.status_active:
-                    view.erase_status('Pylinter')
-                    self.status_active = False
+                if last_selected_line != self.last_selected_line:
+                    self.last_selected_line = last_selected_line
+                    if self.last_selected_line in PYLINTER_ERRORS[view_id]:
+                        err_str = PYLINTER_ERRORS[view_id][self.last_selected_line]
+                        if self.message_stay:
+                            view.set_status('Pylinter', err_str)
+                            self.status_active = True
+                        else:
+                            sublime.status_message(err_str)
+                    elif self.status_active:
+                        view.erase_status('Pylinter')
+                        self.status_active = False
 
 def plugin_loaded():
-    global pylint_settings
-    pylint_settings = sublime.load_settings('Pylinter.sublime-settings')
+    """Load the settings file when the Sublime API is ready"""
+    global LOADED
+    global PYLINT_SETTINGS
+    PYLINT_SETTINGS = sublime.load_settings('Pylinter.sublime-settings')
+    if PYLINT_SETTINGS.get("pylint_path") is None:
+        sublime.error_message("Cannot load Pylinter settings")
+    else:
+        LOADED = True

--- a/pylinter.py
+++ b/pylinter.py
@@ -510,7 +510,7 @@ def plugin_loaded():
     global LOADED
     global PYLINT_SETTINGS
     PYLINT_SETTINGS = sublime.load_settings('Pylinter.sublime-settings')
-    if PYLINT_SETTINGS.get("pylint_path") is None:
+    if PYLINT_SETTINGS.get("python_bin") is None:
         sublime.error_message("Cannot load Pylinter settings")
     else:
         LOADED = True


### PR DESCRIPTION
Removed early call to API, settings now loaded only when API ready. Still a lot of globals. Will perhaps continue this fork to get rid of them. Tested and confirmed to work on OS X 10.9 with Homebrew python 3 and 2.7 for external Pylint.

I also ran Pylint on the file and changed a few things. Not all of the things though.
