### PR TITLE
Make it compatible with Pylint 1.0.0

### DIFF
--- a/pylinter.py
+++ b/pylinter.py
@@ -396,7 +396,6 @@ class PylintThread(threading.Thread):
             command = [self.python_bin,
                        self.pylint_path,
                        '--output-format=parseable',
-                       '--include-ids=y',
                        self.file_name]
         else:
             command = [self.python_bin,


### PR DESCRIPTION
On update to 1.0.0 Pylint removed the flag --include-ids, and it broke the plugin.
