### PR TITLE
output parsing: ignore "Using config file..." message

### DIFF
--- a/pylinter.py
+++ b/pylinter.py
@@ -529,7 +529,8 @@ class PylintThread(threading.Thread):
         # instance, trying to disable a messaage id that does not exist
         if len(errlines) > 1:
             err = errlines[-2]
-            if not err.startswith("No config file found"):
+            if (not err.startswith("No config file found") and
+                    not err.startswith("Using config file")):
                 sublime.error_message("Fatal pylint error:\n%s" % (errlines[-2]))
 
         for line in lines:


### PR DESCRIPTION
Now if pylint rc file exists, the plugin generated an error dialogue on every execution 