### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Thanks to KristoforMaynard for the following additions:
 **2012-09-06**
 
 * Pylinter now allows for platform and/or host specific configuration to be
-  stored in a single configuration file. This is particulary useful for the
+  stored in a single configuration file. This is particularly useful for the
   ``pylint_path`` setting.
 
   Simply change a setting like
@@ -102,7 +102,7 @@ Thanks to KristoforMaynard for the following additions:
   ``#pylint: disable=`` statements/comments.
 * Included wuub's error colouring. Either use the included
   ``MonokaiPylinter.tmTheme`` file, or have a look at it to see how you can
-  colour the different erros and warnings.
+  colour the different errors and warnings.
 
 
 

--- a/pylinter.py
+++ b/pylinter.py
@@ -53,10 +53,10 @@ LAST_SELECTED_LINE = -1
 # Indicates if we're displaying info in the status line
 STATUS_ACTIVE = False
 
-# The followig global values will be set by the `set_globals` function
+# The following global values will be set by the `set_globals` function
 PYLINT_VERSION = None
 PYLINT_SETTINGS = None
-# Regular expression to disect Pylint error messages
+# Regular expression to dissect Pylint error messages
 P_PYLINT_ERROR = None
 
 # The default Pylint command will be stored in this variable. It will either be
@@ -79,7 +79,7 @@ def plugin_loaded():
 
     # Pylint version < 1.0
     if PYLINT_VERSION[0] == 0:
-        # Regular expression to disect Pylint error messages
+        # Regular expression to dissect Pylint error messages
         P_PYLINT_ERROR = re.compile(r"""
             ^(?P<file>.+?):(?P<line>[0-9]+):\ # file name and line number
             \[(?P<type>[a-z])(?P<errno>\d+)   # message type and error number
@@ -434,7 +434,7 @@ class PylinterCommand(sublime_plugin.TextCommand):
 
 
 class PylintThread(threading.Thread):
-    """ This class creates a seperate thread to run Pylint in """
+    """ This class creates a separate thread to run Pylint in """
 
     def __init__(self, view, pbin, ppath, cwd, lpath, lrc, ignore,
                  disable_msgs, extra_pylint_args, plugins):
@@ -525,8 +525,8 @@ class PylintThread(threading.Thread):
         view_id = self.view.id()
         PYLINTER_ERRORS[view_id] = {"visible": True}
 
-        # if pylint raised any exceptions, propogate those to the user, for
-        # instance, trying to disable a messaage id that does not exist
+        # if pylint raised any exceptions, propagate those to the user, for
+        # instance, trying to disable a message id that does not exist
         if len(errlines) > 1:
             err = errlines[-2]
             if not err.startswith("No config file found"):


### PR DESCRIPTION
There are small typos in:
- README.rst
- pylinter.py

Fixes:
- Should read `dissect` rather than `disect`.
- Should read `separate` rather than `seperate`.
- Should read `propagate` rather than `propogate`.
- Should read `particularly` rather than `particulary`.
- Should read `message` rather than `messaage`.
- Should read `following` rather than `followig`.
- Should read `errors` rather than `erros`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md